### PR TITLE
Add quota function

### DIFF
--- a/README
+++ b/README
@@ -5,6 +5,7 @@ SYPNOSIS
   socprint.sh (p|print) [options] <username> <printqueue> [-|<filepath>]
   socprint.sh (j|jobs ) [options] <username> <printqueue>
   socprint.sh (l|list ) [options] <username>
+  socprint.sh (q|quota) [options] <username>
   socprint.sh (h|help )
 
 QUICKSTART
@@ -22,6 +23,7 @@ COMMANDS (shortname|longname)
   (p|print) Print a file at specified printqueue.
   (j|jobs ) List jobs at specified printqueue.
   (l|list ) List all printqueues.
+  (q|quota) Show print quota.
   (h|help ) Show this message.
 
 OPTIONS
@@ -100,7 +102,7 @@ CONTRIBUTORS
 GENERATE README
   ./socprint.sh help > README   && echo "List of valid printqueues, generated with list command on 5 March 2021\n" >> README   && ./socprint.sh list d-lee >> README
 
-List of valid printqueues, generated with list command on 5 March 2021
+List of valid printqueues, generated with list command on 26 March 2021
 
 psts
 psts-sx

--- a/socprint.sh
+++ b/socprint.sh
@@ -249,8 +249,9 @@ EOF
 q | quota)
     check_username "$@"
 
+    # -t is needed because pusage works with interactive ssh and not without. 
+    # Using -t emulates an interaction session. 'man ssh' for details
     cmd=$( cat <<EOF
-    # -t is needed because pusage works with interactive ssh and not without. Using -t emulates an interaction session. 'man ssh' for details
   ssh $sshcmd -t "/usr/local/bin/pusage"
 EOF
 )

--- a/socprint.sh
+++ b/socprint.sh
@@ -246,6 +246,15 @@ l | list)
 EOF
 )
 ;;
+q | quota)
+    check_username "$@"
+
+    cmd=$( cat <<EOF
+    # -t is needed because pusage works with interactive ssh and not without. Using -t emulates an interaction session. 'man ssh' for details
+  ssh $sshcmd -t "/usr/local/bin/pusage"
+EOF
+)
+;;
 esac
 
 [ -z "${cmd-}" ] && die "Error: unknown command: ${command-}"

--- a/tests/socprint.t
+++ b/tests/socprint.t
@@ -56,3 +56,9 @@ Check printer selection works
   $ $TMPDIR/socprint.sh print --dry-run test_user $TMPDIR/acceptable_format.txt
   Error: <printqueue> should start with 'p', e.g. psc008-dx. See PRINTQUEUES in help.
   [1]
+
+Check quota works
+  $ $TMPDIR/socprint.sh quota --dry-run test_user
+  Using test_user@sunfire.comp.nus.edu.sg ...
+    ssh test_user@sunfire.comp.nus.edu.sg -t "/usr/local/bin/pusage"
+


### PR DESCRIPTION
It was a teeny bit fun trying to find the reason why `pquota` does not work if it's a normal ssh command but works on the interactive ssh command. 

So far, I have confirmed that `pquota` does not use `whoami`