### PR TITLE
Fix filetype check

### DIFF
--- a/socprint.sh
+++ b/socprint.sh
@@ -260,8 +260,8 @@ case "${command-}" in
         else
             [ ! -f "${filepath-}" ] && die "Error: No such file"
             # Warn if filetype is unexpected
-            filetype=$( file -i "${filepath}" | cut -f 2 -d ' ')
-            [ "${filetype}" != 'application/pdf;' ] && [ "$( printf '%s' "$filetype" | head -c 4 )" != 'text' ] && msg "Warning: File is not PDF or text. Print behaviour is undefined."
+            filetype=$( file -b --mime-type "${filepath}" )
+            [ "${filetype}" != 'application/pdf' ] && [ "$( printf '%s' "$filetype" | head -c 4 )" != 'text' ] && msg "Warning: File is not PDF or text. Print behaviour is undefined."
         fi
 
   # Generate random 8 character alphanumeric string in a POSIX compliant way


### PR DESCRIPTION
The filetype check was raising false positives because its output included filename.
Exclude the name with -b and also just retrieve the mimetype instead of cutting.

for #22 

Signed-off-by: Donald Lee <dlqs@gmx.com>